### PR TITLE
Class colors, config comands and more

### DIFF
--- a/LootBlare.lua
+++ b/LootBlare.lua
@@ -1,4 +1,4 @@
-﻿local weird_vibes_mode = true
+local weird_vibes_mode = true
 local srRollMessages = {}
 local msRollMessages = {}
 local osRollMessages = {}
@@ -413,6 +413,7 @@ itemRollFrame:SetScript("OnEvent", function () HandleChatMessage(event,arg1,arg2
 
 -- Register the slash command
 SLASH_LOOTBLARE1 = '/lootblare'
+SLASH_LOOTBLARE2 = '/lb'
 
 -- Command handler
 SlashCmdList["LOOTBLARE"] = function(msg)

--- a/LootBlare.lua
+++ b/LootBlare.lua
@@ -395,13 +395,13 @@ end
 
 local function HandleChatMessage(event, message, sender)
   if IsSenderMasterLooter(sender) and (event == "CHAT_MSG_RAID" or event == "CHAT_MSG_RAID_LEADER") then
-    lb_print("message raid from ML detected")
+
     local _,_,duration = string.find(message, "You have (%d+) seconds to roll")
     duration = tonumber(duration)
     if duration and duration ~= FrameShownDuration then
       FrameShownDuration = duration
       -- The players get the new duration from the master looter after the first rolls
-      lb_print("Rolling duration set to " .. FrameShownDuration .. " seconds.")
+      lb_print("Rolling duration set to " .. FrameShownDuration .. " seconds. (set by Master Looter)")
     end
   elseif event == "CHAT_MSG_SYSTEM" and isRolling then
     if string.find(message, "rolls") and string.find(message, "(%d+)") then
@@ -478,8 +478,8 @@ SlashCmdList["LOOTBLARE"] = function(msg)
       itemRollFrame:Show()
     end
   elseif msg == "help" then
-    lb_print("LootBlare is a simple addon that displays item rolls in a frame.")
-    lb_print("Type /lb time <seconds> to set the duration the frame is shown.")
+    lb_print("LootBlare is a simple addon that displays and sort item rolls in a frame.")
+    lb_print("Type /lb time <seconds> to set the duration the frame is shown. This value will be automatically set by the master looter after the first rolls.")
     lb_print("Type /lb autoClose on/off to enable/disable auto closing the frame after the time has elapsed.")
     lb_print("Type /lb settings to see the current settings.")
   elseif msg == "settings" then

--- a/LootBlare.lua
+++ b/LootBlare.lua
@@ -396,7 +396,7 @@ end
 local function HandleChatMessage(event, message, sender)
   if IsSenderMasterLooter(sender) and (event == "CHAT_MSG_RAID" or event == "CHAT_MSG_RAID_LEADER") then
 
-    local _,_,duration = string.find(message, "You have (%d+) seconds to roll")
+    local _,_,duration = string.find(message, "Roll time set to (%d+) seconds")
     duration = tonumber(duration)
     if duration and duration ~= FrameShownDuration then
       FrameShownDuration = duration
@@ -431,7 +431,7 @@ local function HandleChatMessage(event, message, sender)
       playerName = UnitName("player")
       if playerName == sender then
         -- send chat message to the raid
-        SendChatMessage("Rolling is now open for " .. message .. ". You have " .. FrameShownDuration .. " seconds to roll.", "RAID")
+        SendChatMessage("Rolling is now open for " .. message .. ". Roll time set to " .. FrameShownDuration .. " seconds.", "RAID")
       end
       local links = ExtractItemLinksFromMessage(message)
       if tsize(links) == 1 then
@@ -490,7 +490,10 @@ SlashCmdList["LOOTBLARE"] = function(msg)
     newDuration = tonumber(newDuration)
     if newDuration and newDuration > 0 then
       FrameShownDuration = newDuration
-      lb_print("Frame shown duration set to " .. newDuration .. " seconds.")
+      lb_print("Roll time set to " .. newDuration .. " seconds.")
+      if IsSenderMasterLooter(UnitName("player")) then
+        SendChatMessage("Roll time set to " .. newDuration .. " seconds.", "RAID")
+      end
     else
       lb_print("Invalid duration. Please enter a number greater than 0.")
     end

--- a/LootBlare.lua
+++ b/LootBlare.lua
@@ -4,6 +4,7 @@ local msRollMessages = {}
 local osRollMessages = {}
 local tmogRollMessages = {}
 local rollers = {}
+local isRolling = false
 local time_elapsed = 0
 local item_query = 0.5
 local times = 5
@@ -293,7 +294,8 @@ local function ShowFrame(frame,duration,item)
       item_query = 1.5
       times = 3
       rollMessages = {}
-      if frameAutoClose then frame:Hide() end
+      isRolling = false
+      if FrameAutoClose then frame:Hide() end
     end
     if times > 0 and item_query < 0 and not CheckItem(item) then
       times = times - 1
@@ -393,8 +395,7 @@ local function IsUnitMasterLooter(unit)
   return false
 end
 
-local function HandleChatMessage(event, message, from)
-  if event == "CHAT_MSG_SYSTEM" and itemRollFrame:IsShown() then
+  if event == "CHAT_MSG_SYSTEM" and isRolling then
     if string.find(message, "rolls") and string.find(message, "(%d+)") then
       local _,_,roller, roll, minRoll, maxRoll = string.find(message, "(%S+) rolls (%d+) %((%d+)%-(%d+)%)")
       if roller and roll and rollers[roller] == nil then
@@ -432,8 +433,8 @@ local function HandleChatMessage(event, message, from)
         resetRolls()
         UpdateTextArea(itemRollFrame)
         time_elapsed = 0
+        isRolling = true
         ShowFrame(itemRollFrame,FrameShownDuration,links[1])
-        -- SetItemInfo(itemRollFrame,links[1])
       end
     end
   elseif event == "ADDON_LOADED" and arg1 == "LootBlare" then

--- a/LootBlare.toc
+++ b/LootBlare.toc
@@ -3,6 +3,6 @@
 ## Author: Ehawne, Sivent, Gulolio
 ## Version: 1.1.6
 ## Notes: Make loot rolls obvious
-## SavedVariables:FrameShownDuration, frameAutoClose
+## SavedVariables:FrameShownDuration, FrameAutoClose
 
 LootBlare.lua

--- a/LootBlare.toc
+++ b/LootBlare.toc
@@ -3,6 +3,6 @@
 ## Author: Ehawne, Sivent, Gulolio
 ## Version: 1.1.6
 ## Notes: Make loot rolls obvious
-## SavedVariables:FrameShownDuration
+## SavedVariables:FrameShownDuration, frameAutoClose
 
 LootBlare.lua

--- a/LootBlare.toc
+++ b/LootBlare.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
-## Title: LootBlare 1.1.6
+## Title: LootBlare 1.1.7
 ## Author: Ehawne, Sivent, Gulolio
-## Version: 1.1.6
+## Version: 1.1.7
 ## Notes: Make loot rolls obvious
 ## SavedVariables:FrameShownDuration, FrameAutoClose
 

--- a/readme.md
+++ b/readme.md
@@ -1,21 +1,47 @@
-Loot Blare 1.1.6
-===
+# Loot Blare 1.1.7
 
-A frame that pops up and shows item and rolls when a single uncommon+ item is linked in Raid Warning.  
+Loot Blare is a World of Warcraft addon originally designed **Turtle WoW**. The original version of this addon can be found [here](https://github.com/MarcelineVQ/LootBlare)
 
-Default frame duration to stay on screen without a new /roll occuring is `20 seconds`, change with:  
-`/lootblare <number>`  
-Make the frame appear to move it with:  
-`/lootblare`
+This addon displays a pop-up frame showing items and rolls when a single uncommon+ item is linked in Raid Warning. Rolls are automatically sorted by type to streamline the master looter's workflow.
 
-### The (moveable) frame in game:  
-![LootBlare Frame](./lootblareframe.png)  
+### Features:
 
-* This addon is made by and for `Weird Vibes` of Turtle WoW.  
+- **Start Rolling**: To start the rolling process, send the item as a **Raid Warning**. This will trigger the frame to appear and display rolls. The frame only appears when the sender of the raid warning is the master looter.
 
-changelog:
+- **Roll Sorting**: Rolls are automatically categorized and sorted by type to streamline loot distribution. Only the first roll submitted by each player is considered; subsequent rolls are ignored.
 
-1.1.6 -> Simple Buttons and Tooltips
-1.1.5 -> Added button for SR and roll type order and color
-1.1.4 -> Added more buttons for OS and Tmog and now only will register the first roll of each player
-1.1.3 -> Added MainSpec Button for rolling
+- **Show/Hide Frame**: To show or hide the frame, type:  
+  `/lootblare` or `/lb`  
+  If the frame is active, you can move it by dragging.
+
+- **Easy Roll Buttons**: For raiders, the addon provides convenient roll buttons:
+
+  - **SR (Soft Reserve)**: Rolls from 1 to 101.
+  - **MS (Main Spec)**: Rolls from 1 to 100.
+  - **OS (Off Spec)**: Rolls from 1 to 99.
+  - **TM (Transmog)**: Rolls from 1 to 50.
+
+- **Frame Duration**: By default, the frame stays on screen for `15 seconds` unless a new roll occurs. Adjust this duration with:  
+  `/lootblare 'time <number>` or `/lb 'time <number>`
+
+  Example: `/lootblare 'time 30` to set the duration to 30 seconds.
+
+The Master Looter announces the frame duration at the start of each rolling session or immediately after updating the value with `/lb time <number>`. This announced value is applied to the entire raid to ensure consistency.
+
+- **Auto-Close**: The frame closes automatically after the set time. Toggle this feature on or off with:  
+  `/lootblare autoClose on/off` or `/lb autoClose on/off`
+
+- **Configuration Commands**: For a full list of configuration options, type:  
+  `/help`
+
+### The (moveable) frame in game:
+
+![LootBlare Frame](./lootblareframe.png)
+
+Changelog:
+
+- **1.1.7**: Added class colors, autoClose option, and config commands. Only show frame if the sender is the ML. Ignore rolls after the time has elapsed. Get FrameShowDuration from the ML.
+- **1.1.6**: Simple Buttons and Tooltips.
+- **1.1.5**: Added button for SR and roll type order and color.
+- **1.1.4**: Added more buttons for OS and Tmog. Now only registers the first roll of each player.
+- **1.1.3**: Added MainSpec Button for rolling.


### PR DESCRIPTION
List of changes:

- [x]  Add `/lb` as a slash command
- [x] Add class colors to players names in the text area
- [x] Add new saved variable `FrameAutoClose`
- [x] Rework slash commands. Now we have:
-  `/lootblare` or `/lb` to show or hide the frame
- `/lootblare time <seconds>` or `/lb time <seconds>` to update `FrameShownDuration`
- `/lootblare autoClose on/off` or `/lb autoClose on/off` to update `FrameAutoClose`
- `/lootblare help` or `/lb help` to display some addon information
- `/lootblare settings` or `/lb settings` to display current values of `FrameShownDuration` and `FrameAutoClose`
- [x] Add `isRolling` variable to ignore rolls after rolling time has ended, even if the frame is still open
- [x] Only show the frame if the item is linked by the ML
- [x] The ML now announces the roll time after each roll and after updating this value with `/lb time <seconds>`
- [x] The raiders now update the roll time using ML announcements if the value has changed 
- [x] Update version in .toc
- [x] Update `readme.md` 