### PR TITLE
bugfix-IsSenderMasterLooter-function-not-working

### DIFF
--- a/LootBlare.lua
+++ b/LootBlare.lua
@@ -394,7 +394,7 @@ end
 
 
 local function HandleChatMessage(event, message, sender)
-  if IsSenderMasterLooter(sender) and (event == "CHAT_MSG_RAID" or event == "CHAT_MSG_RAID_LEADER") then
+  if (event == "CHAT_MSG_RAID" or event == "CHAT_MSG_RAID_LEADER") then
     local _,_,duration = string.find(message, "Roll time set to (%d+) seconds")
     duration = tonumber(duration)
     if duration and duration ~= FrameShownDuration then
@@ -431,26 +431,23 @@ local function HandleChatMessage(event, message, sender)
     end
 
   elseif event == "CHAT_MSG_RAID_WARNING" then
-    local isSenderML = IsSenderMasterLooter(sender)
-    if isSenderML then -- only show if the sender is the master looter
-      local links = ExtractItemLinksFromMessage(message)
-      if tsize(links) == 1 then
-        if string.find(message, "^No one has need:") or
-           string.find(message,"has been sent to") or
-           string.find(message, " received ") then
-          itemRollFrame:Hide()
-          return
-        elseif string.find(message,"Rolling Cancelled") or -- usually a cancel is accidental in my experience
-               string.find(message,"seconds left to roll") or
-               string.find(message,"Rolling is now Closed") then
-          return
-        end
-        resetRolls()
-        UpdateTextArea(itemRollFrame)
-        time_elapsed = 0
-        isRolling = true
-        ShowFrame(itemRollFrame,FrameShownDuration,links[1])
+    local links = ExtractItemLinksFromMessage(message)
+    if tsize(links) == 1 then
+      if string.find(message, "^No one has need:") or
+          string.find(message,"has been sent to") or
+          string.find(message, " received ") then
+        itemRollFrame:Hide()
+        return
+      elseif string.find(message,"Rolling Cancelled") or -- usually a cancel is accidental in my experience
+              string.find(message,"seconds left to roll") or
+              string.find(message,"Rolling is now Closed") then
+        return
       end
+      resetRolls()
+      UpdateTextArea(itemRollFrame)
+      time_elapsed = 0
+      isRolling = true
+      ShowFrame(itemRollFrame,FrameShownDuration,links[1])
     end
   elseif event == "ADDON_LOADED" and arg1 == "LootBlare" then
     if FrameShownDuration == nil then FrameShownDuration = 15 end

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This addon displays a pop-up frame showing items and rolls when a single uncommo
 
 ### Features:
 
-- **Start Rolling**: To start the rolling process, send the item as a **Raid Warning**. This will trigger the frame to appear and display rolls. The frame only appears when the sender of the raid warning is the master looter.
+- **Start Rolling**: To start the rolling process, send the item as a **Raid Warning**. This will trigger the frame to appear and display rolls.
 
 - **Roll Sorting**: Rolls are automatically categorized and sorted by type to streamline loot distribution. Only the first roll submitted by each player is considered; subsequent rolls are ignored.
 


### PR DESCRIPTION
List of changes:

- [x] Stop checking if the RW was sent by the ML. Every RW will open the frame

Right now I don't know how to get the master looter's name or id. According to https://wowwiki-archive.fandom.com/wiki/API_GetLootMethod?oldid=286028 the method we were using is not able to properly get the ML id 