### PR TITLE
Add communication and check for ML

### DIFF
--- a/LootBlare.lua
+++ b/LootBlare.lua
@@ -429,7 +429,6 @@ local function HandleChatMessage(event, message, sender)
         elseif maxRoll == "50" then
           table.insert(tmogRollMessages, message)
         end
-        time_elapsed = 0
         UpdateTextArea(itemRollFrame)
       end
     end

--- a/LootBlare.lua
+++ b/LootBlare.lua
@@ -463,7 +463,7 @@ local function HandleChatMessage(event, message, sender)
     else
       SendAddonMessage(LB_PREFIX, LB_GET_DATA, "RAID")
     end
-  elseif event == "CHAT_MSG_ADDON" then
+  elseif event == "CHAT_MSG_ADDON" and arg1 == LB_PREFIX then
     local prefix, message, channel, sender = arg1, arg2, arg3, arg4
 
     -- Someone is asking for the master looter and his roll time

--- a/LootBlare.lua
+++ b/LootBlare.lua
@@ -434,9 +434,10 @@ local function HandleChatMessage(event, message, sender)
       end
     end
 
-  elseif event == "CHAT_MSG_RAID_WARNING" then
+  elseif event == "CHAT_MSG_RAID_WARNING" and sender == masterLooter then
     local links = ExtractItemLinksFromMessage(message)
     if tsize(links) == 1 then
+      -- these if are not being used RN. I'm just leaving them here for future reference
       if string.find(message, "^No one has need:") or
           string.find(message,"has been sent to") or
           string.find(message, " received ") then
@@ -484,7 +485,7 @@ local function HandleChatMessage(event, message, sender)
       duration = tonumber(duration)
       if duration and duration ~= FrameShownDuration then
         FrameShownDuration = duration
-        lb_print("Roll time set to comunication" .. FrameShownDuration .. " seconds.")
+        lb_print("Roll time set to " .. FrameShownDuration .. " seconds.")
       end
     end
   end

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Loot Blare 1.1.8
+# Loot Blare 1.1.9
 
 Loot Blare is a World of Warcraft addon originally designed **Turtle WoW**. The original version of this addon can be found [here](https://github.com/MarcelineVQ/LootBlare)
 
@@ -42,6 +42,7 @@ Every time the master looter changes, the new master looter announces the roll t
 
 Changelog:
 
+- **1.1.9**: Add communication using CHAT_MSG_ADDON events
 - **1.1.8**: Remove announce message after each roll. Added time announce message after changing master loot
 - **1.1.7**: Added class colors, autoClose option, and config commands. Only show frame if the sender is the ML. Ignore rolls after the time has elapsed. Get FrameShowDuration from the ML.
 - **1.1.6**: Simple Buttons and Tooltips.

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This addon displays a pop-up frame showing items and rolls when a single uncommo
 
 ### Features:
 
-- **Start Rolling**: To start the rolling process, send the item as a **Raid Warning**. This will trigger the frame to appear and display rolls.
+- **Start Rolling**: To start the rolling process, send the item as a **Raid Warning**. This will trigger the frame to appear and display rolls. The frame will appear only if the sender is the ML
 
 - **Roll Sorting**: Rolls are automatically categorized and sorted by type to streamline loot distribution. Only the first roll submitted by each player is considered; subsequent rolls are ignored.
 
@@ -33,6 +33,8 @@ Every time the master looter changes, the new master looter announces the roll t
 
 - **Configuration Commands**: For a full list of configuration options, type:  
   `/help`
+
+- **Communication**: The addon uses the addon channel to update data about roll time and the current master looter. For example, if the player logs in after the ML has been set, he will automatically ask who the ML is and the ML will answer. Also, the ML will announce that he is the ML on add-on loading. All of this is invisible to the player
 
 ### The (moveable) frame in game:
 


### PR DESCRIPTION
List of changes:

- [x] Add internal addon communication using CHAT_MSG_ADDON events
- [x] Now the ML announces his config using this addon when "asked" or when loading the addon
- [x] When the addon loads it "ask" for info to the ML. The ML then sends his config and updates the variable `masterLooter` for everyone 
- [x] Using the variable `masterLooter` only opens the frame if the raid warning was sent by the ML
- [x] Do not reset timer when someone rolls